### PR TITLE
Used file copying instead of moving

### DIFF
--- a/qr-filetransfer.py
+++ b/qr-filetransfer.py
@@ -8,7 +8,7 @@ import os
 import socket
 import argparse
 import sys
-from shutil import make_archive, move, rmtree
+from shutil import make_archive, move, rmtree, copy2
 import pathlib
 
 def get_local_ip():
@@ -51,7 +51,7 @@ def start_server(fname):
     
     try:
         # Move the file to .tmpqr
-        move(fname, TEMP_DIR_NAME)
+        copy2(fname, TEMP_DIR_NAME)
     except FileNotFoundError:
         print("File not found!")
         rmtree(TEMP_DIR_NAME)


### PR DESCRIPTION
I propose this change for two reasons:
1. The user might freak out if his/her file disappeared while the transfer was happening
2. If we don't do this, the file moved earlier would get deleted after the process finished (leaving the user with no file).

Fixes #4 