### PR TITLE
Prevent deocding failed by simply insert a escape sequence

### DIFF
--- a/qr-filetransfer/qr-filetransfer
+++ b/qr-filetransfer/qr-filetransfer
@@ -105,7 +105,7 @@ def FileUploadServerHandlerClass(output_dir):
             while remainbytes > 0:
                 line = self.rfile.readline()
                 remainbytes -= len(line)
-                fn = re.findall(r'Content-Disposition.*name="file"; filename="(.*)"', line.decode())
+                fn = re.findall(r'Content-Disposition.*name="file"; filename="(.*)"', line.decode("utf-8", "backslashreplace"))
                 if not fn:
                     return (False, "Can't find out file name...")
                 fn = os.path.join(self._output_dir, fn[0])


### PR DESCRIPTION
The problem is \x cannot be decoded. Simply add an escape sequence to workaround this problem.

This will workaround issue #24 .