### PR TITLE
Set html encoding to utf-8

### DIFF
--- a/qr-filetransfer/qr-filetransfer
+++ b/qr-filetransfer/qr-filetransfer
@@ -112,7 +112,7 @@ def FileUploadServerHandlerClass(output_dir):
             length = f.tell()
             f.seek(0)
             self.send_response(200)
-            self.send_header("Content-type", "text/html")
+            self.send_header("Content-type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(length))
             self.end_headers()
             if f:
@@ -187,7 +187,7 @@ def FileUploadServerHandlerClass(output_dir):
             length = f.tell()
             f.seek(0)
             self.send_response(200)
-            self.send_header("Content-type", "text/html")
+            self.send_header("Content-type", "text/html; charset=utf-8")
             self.send_header("Content-Length", str(length))
             self.end_headers()
             return f


### PR DESCRIPTION
So that it can correct deal filename with Chinese words.
Fix #26.

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>