### PR TITLE
specify codec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open('README.md', 'r') as fh:
+with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
 setuptools.setup(


### PR DESCRIPTION
set `utf-8` as codec that Windows 10 in Chinese won't use `gbk` codec, which would raise a `UnicodeDecodeError` during installation.