### PR TITLE
Fixes issue #43 where files are displayed in the browser instead of downloading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ optional arguments:
   --ip_addr {192.168.0.105}
                         specify IP address
   --auth AUTH           add authentication, format: username:password
+  --no-force-download   Allow browser to handle the file processing instead of
+                        forcing it to download.
 ```
 
 **Note:** Both devices needs to be connected to the same network

--- a/qr_filetransfer/qr_filetransfer.py
+++ b/qr_filetransfer/qr_filetransfer.py
@@ -104,6 +104,17 @@ def FileTransferServerHandlerClass(file_name, auth, debug):
             else:
                 super().do_GET()
 
+        def guess_type(self, path):
+            """Always force download.
+
+            Args:
+                path: Placeholder that we're going to ignore.
+
+            Returns:
+                Content-Type as a string.
+            """
+            return "application/octet-stream"
+
         def log_message(self, format, *args):
             if self._debug:
                 super().log_message(format, *args)


### PR DESCRIPTION
This change forces all file transfers to have the Content-Type set to "application/octet-stream" resulting in the file downloading instead of being displayed in the browser.