### PR TITLE
remove workarounds when using Windows Terminal

### DIFF
--- a/qr_filetransfer/qr_filetransfer.py
+++ b/qr_filetransfer/qr_filetransfer.py
@@ -52,7 +52,7 @@ def cursor(status):
     #
     # Hide cursor: \033[?25h
     # Enable cursor: \033[?25l
-    if operating_system != Windows:
+    if operating_system != Windows or 'WT_SESSION' in os.environ:
         print("\033[?25" + ("h" if status else "l"), end="")
 
 
@@ -554,11 +554,10 @@ def main():
 
     args = parser.parse_args()
 
-    # For Windows, emulate support for ANSI escape sequences and clear the screen first
-    if operating_system == Windows:
+    # For Windows, emulate support for ANSI escape sequences unless Windows Terminal is used
+    if operating_system == Windows and 'WT_SESSION' not in os.environ:
         import colorama
         colorama.init()
-        print("\033[2J", end="")
 
     # We are disabling the cursor so that the output looks cleaner
     cursor(False)


### PR DESCRIPTION
Windows Terminal v1.3.2651, which was released to the stable channel (and the Windows Store) on September 22, now correctly supports all ANSI escape sequences used by qr-filetransfer. This PR removes the colorama workarounds when running under Windows Terminal.

It also removes the clear-screen which was only needed for older Windows Terminal versions. (It was never needed for the "regular" conhost.)